### PR TITLE
Use stable kernel when possible and disable opensnitch

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -9,12 +9,11 @@
       ./modules/gnome.nix
       ./modules/jetbrains.nix
       ./modules/opensnitch.nix
+      ./modules/rust.nix
       ./modules/signal.nix
       ./modules/spotify.nix
       ./modules/wireshark.nix
     ];
-  # Use the newest kernel.
-  boot.kernelPackages = pkgs.linuxPackages_latest;
 
   # Set a limit on the number of generations to include in boot
   boot.loader.systemd-boot.configurationLimit = 20;

--- a/dell.nix
+++ b/dell.nix
@@ -6,7 +6,6 @@
       (modulesPath + "/installer/scan/not-detected.nix")
       ./base.nix
       ./modules/encrypted-dns.nix
-      ./modules/rust.nix
       ./modules/steam.nix
     ];
 

--- a/desktop.nix
+++ b/desktop.nix
@@ -1,4 +1,4 @@
-{ config, lib, modulesPath, ... }:
+{ config, lib, modulesPath, pkgs, ... }:
 
 {
   imports =
@@ -8,6 +8,9 @@
       ./modules/work.nix
       # ./modules/encrypted-dns.nix
     ];
+
+  # Use the newest kernel.
+  boot.kernelPackages = pkgs.linuxPackages_latest;
 
   boot.initrd.availableKernelModules = [ "nvme" "xhci_pci" "ahci" "usb_storage" "usbhid" "sd_mod" ];
   boot.initrd.kernelModules = [ ];

--- a/modules/jetbrains.nix
+++ b/modules/jetbrains.nix
@@ -1,7 +1,8 @@
 { config, pkgs, lib, ... }:
 let
+  url = import ../unstable_url.nix;
   unstable = import
-    (builtins.fetchTarball "https://github.com/nixos/nixpkgs/tarball/3a5eb38af0215cd697a78c25ececdab111f21388")
+    (builtins.fetchTarball url)
     { config = config.nixpkgs.config; };
 in
 {

--- a/modules/opensnitch.nix
+++ b/modules/opensnitch.nix
@@ -11,7 +11,7 @@
 
   # A list of general rules needed no matter how the system is configured
   services.opensnitch = {
-    enable = true;
+    enable = false;
     settings.DefaultAction = "deny";
     rules = {
       rule-000-firefox = {

--- a/unstable_url.nix
+++ b/unstable_url.nix
@@ -1,0 +1,1 @@
+"https://github.com/nixos/nixpkgs/tarball/3a5eb38af0215cd697a78c25ececdab111f21388"


### PR DESCRIPTION
Something is wrong upstream and opensnitch gets in a crash loop at startup